### PR TITLE
Update Sailthru/Sailthru/SailthruClient.cs

### DIFF
--- a/Sailthru/Sailthru/SailthruClient.cs
+++ b/Sailthru/Sailthru/SailthruClient.cs
@@ -66,8 +66,8 @@ namespace Sailthru
         public bool ReceiveOptoutPost(NameValueCollection parameters)
         {
             List<string> requiredParams = new List<string> { "action", "email", "sig" };
-            foreach (String key in parameters.Keys) {
-                if (!requiredParams.Contains(key)) {
+            foreach (String key in requiredParams) {
+                if (!parameters.ContainsKey(key)) {
                     return false;
                 }
             }


### PR DESCRIPTION
Updated a bug where ReceiveOptoutPost would return false no matter what (if optout exists in parameters, then it will fail if(!parameters.ContainsKey(key)), but if it doesn't exist in parameters, then it will fail if( parameters.Get("optout" == null))
