### PR TITLE
bugzid:9150  - remove serialization of null when using newtonsoft json

### DIFF
--- a/Sailthru/Sailthru/SailthruClient.cs
+++ b/Sailthru/Sailthru/SailthruClient.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿using System;
+﻿﻿﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -370,7 +370,7 @@ namespace Sailthru
         public SailthruResponse SetEmail(EmailRequest request)
         {
             Hashtable hashForPost = new Hashtable();
-        	hashForPost.Add("json", JsonConvert.SerializeObject(request, Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            hashForPost.Add("json", JsonConvert.SerializeObject(request, Formatting.None, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
 
             return this.ApiPost("email", hashForPost);
         }


### PR DESCRIPTION
It turns out that it only ignores it if the value of a field specifically is null, but not if there is a null value inside of a hashmap.  Thus, we just need to tell it to ignore nulls
