### PR TITLE
Add Cookies to User Class

### DIFF
--- a/Sailthru/Sailthru.Models/UserRequest.cs
+++ b/Sailthru/Sailthru.Models/UserRequest.cs
@@ -71,6 +71,15 @@ namespace Sailthru.Models
 		public Hashtable Vars { private get; set; }
 
 		/// <summary>
+		/// Gets or sets the anonymous cookie.
+		/// </summary>
+		/// <value>
+		/// The cookies.
+		/// </value>
+		[JsonProperty(PropertyName = "cookies")]
+		public Hashtable Cookies { private get; set; }
+
+		/// <summary>
 		/// set custom variables on the user
 		/// </summary>
 		/// <value>


### PR DESCRIPTION
Adding the ability to add cookies to a user request. Is necessary to convert anonymous users to known users.