### PR TITLE
Fix Unicode support

### DIFF
--- a/Sailthru/Sailthru.Tests/Mock/ApiServer.cs
+++ b/Sailthru/Sailthru.Tests/Mock/ApiServer.cs
@@ -12,6 +12,7 @@ namespace Sailthru.Tests.Mock
     public class ApiServer
     {
         private const String API_URL = "http://localhost:5555";
+        private static JsonSerializerSettings jsonSettings;
 
         private readonly HttpListener listener;
         private readonly Thread listenerThread;
@@ -30,6 +31,9 @@ namespace Sailthru.Tests.Mock
             listenerThread = new Thread(HandleRequests);
             listenerThread.IsBackground = true;
             listenerThread.Start();
+
+            jsonSettings = new JsonSerializerSettings();
+            jsonSettings.StringEscapeHandling = StringEscapeHandling.EscapeNonAscii;
         }
 
         public String ApiUrl
@@ -83,7 +87,7 @@ namespace Sailthru.Tests.Mock
                 context.Response.AddHeader("Content-Type", "application/json");
                 using (StreamWriter writer = new StreamWriter(context.Response.OutputStream))
                 {
-                    writer.Write(JsonConvert.SerializeObject(response));
+                    writer.Write(JsonConvert.SerializeObject(response, jsonSettings));
                 }
             }
 

--- a/Sailthru/Sailthru.Tests/Mock/UserApi.cs
+++ b/Sailthru/Sailthru.Tests/Mock/UserApi.cs
@@ -7,10 +7,10 @@ namespace Sailthru.Tests.Mock
     {
         public static object ProcessPost(JObject request)
         {
-            string id = request["id"].Value<string>();
-            string optout = request["optout_email"].Value<string>();
-            JObject vars = request["vars"].Value<JObject>();
-            JObject fields = request["fields"].Value<JObject>();
+            string id = (string)request["id"];
+            string optout = (string)request["optout_email"];
+            JObject vars = (JObject)request["vars"];
+            JObject fields = (JObject)request["fields"];
             bool returnVars = fields != null && fields.ContainsKey("vars") && fields["vars"].Value<int>() == 1;
             bool returnOptout = fields != null && fields.ContainsKey("optout_email") && fields["optout_email"].Value<int>() == 1;
             Dictionary<string, object> result = new Dictionary<string, object>()

--- a/Sailthru/Sailthru.Tests/Mock/UserApi.cs
+++ b/Sailthru/Sailthru.Tests/Mock/UserApi.cs
@@ -11,8 +11,8 @@ namespace Sailthru.Tests.Mock
             string optout = request["optout_email"].Value<string>();
             JObject vars = request["vars"].Value<JObject>();
             JObject fields = request["fields"].Value<JObject>();
-            bool returnVars = fields != null && fields["vars"].Value<int>() == 1;
-            bool returnOptout = fields != null && fields["optout_email"].Value<int>() == 1;
+            bool returnVars = fields != null && fields.ContainsKey("vars") && fields["vars"].Value<int>() == 1;
+            bool returnOptout = fields != null && fields.ContainsKey("optout_email") && fields["optout_email"].Value<int>() == 1;
             Dictionary<string, object> result = new Dictionary<string, object>()
             {
                 ["ok"] = true

--- a/Sailthru/Sailthru.Tests/Test.cs
+++ b/Sailthru/Sailthru.Tests/Test.cs
@@ -61,8 +61,6 @@ namespace Sailthru.Tests
 
             UserRequest request = new UserRequest();
             request.Id = "test@sailthru.com";
-            request.Login = "test@sailthru.com";
-            request.OptoutEmail = OptoutStatus.Basic;
             request.Vars = new Hashtable()
             {
                 ["unicode"] = unicodeString

--- a/Sailthru/Sailthru.Tests/Test.cs
+++ b/Sailthru/Sailthru.Tests/Test.cs
@@ -55,6 +55,31 @@ namespace Sailthru.Tests
         }
 
         [Test]
+        public void UnicodeResponse()
+        {
+            string unicodeString = "ä好😃⇔";
+
+            UserRequest request = new UserRequest();
+            request.Id = "test@sailthru.com";
+            request.Login = "test@sailthru.com";
+            request.OptoutEmail = OptoutStatus.Basic;
+            request.Vars = new Hashtable()
+            {
+                ["unicode"] = unicodeString
+            };
+            request.Fields = new Hashtable()
+            {
+                ["vars"] = 1,
+            };
+
+            SailthruResponse response = client.SetUser(request);
+            Assert.IsTrue(response.IsOK());
+
+            Hashtable vars = response.HashtableResponse["vars"] as Hashtable;
+            Assert.AreEqual(vars["unicode"], unicodeString);
+        }
+
+        [Test]
         public void PostEvent()
         {
             EventRequest request = new EventRequest();

--- a/Sailthru/Sailthru/JSON.cs
+++ b/Sailthru/Sailthru/JSON.cs
@@ -283,7 +283,7 @@ namespace Sailthru
                             // parse the 32 bit hex into an integer codepoint
                             uint codePoint = UInt32.Parse(new string(unicodeCharArray), NumberStyles.HexNumber);
                             // convert the integer codepoint to a unicode char and add to string
-                            s.Append(Char.ConvertFromUtf32((int)codePoint));
+                            s.Append((char)codePoint);
                             // skip 4 chars
                             index += 4;
                         }


### PR DESCRIPTION
 * Modify mock API server to use Unicode escape sequences when serializing JSON
 * Add test to check that non-ASCII text (accented, emoji, Chinese, other) can be transferred correctly back-and-forth
 * Actually fix the issue:
> JSON uses UTF-16 encoding for escaped characters, which is the same as what C# is using. So we can just directly convert the code points to C# chars. The previous version was incorrectly assuming the encoding in JSON was UTF-32, which failed on surrogate pairs