### PR TITLE
[DEVOPS-372] Fix ScheduleBlast call

### DIFF
--- a/Sailthru/Sailthru.Models/BlastRequest.cs
+++ b/Sailthru/Sailthru.Models/BlastRequest.cs
@@ -247,15 +247,6 @@ namespace Sailthru.Models
         public int EmailHourRange { get; set; }
 
         /// <summary>
-        /// Gets or sets the test percent.
-        /// </summary>
-        /// <value>
-        /// The test percent.
-        /// </value>
-        [JsonProperty(PropertyName = "test_percent")]
-        public int TestPercent { get; set; }
-
-        /// <summary>
         /// Gets or sets the data feed URL.
         /// </summary>
         /// <value>

--- a/Sailthru/Sailthru.Tests/Mock/ApiServer.cs
+++ b/Sailthru/Sailthru.Tests/Mock/ApiServer.cs
@@ -121,6 +121,10 @@ namespace Sailthru.Tests.Mock
             {
                 return UserApi.ProcessPost(requestBody);
             }
+            else if (method == "POST" && path == "/blast")
+            {
+                return BlastApi.ProcessPost(requestBody);
+            }
             else
             {
                 throw new FileNotFoundException();

--- a/Sailthru/Sailthru.Tests/Mock/BlastApi.cs
+++ b/Sailthru/Sailthru.Tests/Mock/BlastApi.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Newtonsoft.Json.Linq;
+
+namespace Sailthru.Tests.Mock
+{
+    public static class BlastApi
+    {
+        private static int currentId = 1000;
+
+        public static object ProcessPost(JObject request)
+        {
+            int blastId = Interlocked.Increment(ref currentId);
+            string name = request["name"].Value<string>();
+            string subject = request["subject"].Value<string>();
+            string list = request["list"].Value<string>();
+            string modifyTime = DateTime.Now.ToLocalTime().ToString("ddd, dd MMM yyyy HH:mm:ss zzz");
+
+            return new Dictionary<string, object>
+            {
+                ["blast_id"] = blastId,
+                ["name"] = name,
+                ["subject"] = subject,
+                ["list"] = list,
+                ["modify_time"] = modifyTime,
+                ["status"] = "created"
+            };
+        }
+    }
+}

--- a/Sailthru/Sailthru.Tests/Test.cs
+++ b/Sailthru/Sailthru.Tests/Test.cs
@@ -202,5 +202,21 @@ namespace Sailthru.Tests
             Hashtable purchaseKeys = purchaseResult["purchase_keys"] as Hashtable;
             Assert.AreEqual(purchaseKeys["extid"], "12345");
         }
+
+        [Test]
+        public void PostDraftBlast()
+        {
+            BlastRequest request = new BlastRequest
+            {
+                Name = "test",
+                List = "list",
+                Subject = "test"
+            };
+
+            SailthruResponse response = client.ScheduleBlast(request);
+            Assert.IsTrue(response.IsOK());
+            Assert.AreEqual(response.HashtableResponse["status"], "created");
+            Assert.AreEqual(response.HashtableResponse["name"], "test");
+        }
     }
 }


### PR DESCRIPTION
The presence of the deprecated `test_percent` parameter prevented any requests from being accepted.

Fixes issue #47