### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: csharp
 solution: Sailthru/Sailthru.sln
+dist: bionic
 
 jobs:
   include:


### PR DESCRIPTION
Builds were failing due to an error reported here:
https://travis-ci.community/t/c-build-failing-with-f-errors-even-when-project-does-not-use-f/10805

Upgrading the distribution from Xenial to Bionic fixes it apparently