### PR TITLE
Correctly bundle Sailthru Models DLL in Nuget package

### DIFF
--- a/Sailthru/Sailthru/Sailthru.csproj
+++ b/Sailthru/Sailthru/Sailthru.csproj
@@ -13,6 +13,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>Sailthru.Client</PackageId>
     <PackageTags>Sailthru</PackageTags>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2PAssets</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +25,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Sailthru.Models\Sailthru.Models.csproj" />
+    <ProjectReference Include="..\Sailthru.Models\Sailthru.Models.csproj" PrivateAssets="All" />
   </ItemGroup>
+
+  <Target Name="IncludeP2PAssets">
+    <ItemGroup>
+      <BuildOutputInPackage Include="$(OutputPath)\Sailthru.Models.dll" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/Sailthru/Sailthru/Sailthru.csproj
+++ b/Sailthru/Sailthru/Sailthru.csproj
@@ -10,6 +10,7 @@
     <Authors>Sailthru</Authors>
     <Company>Sailthru, Inc.</Company>
     <PackageProjectUrl>https://github.com/sailthru/sailthru-net-client</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>Sailthru.Client</PackageId>
     <PackageTags>Sailthru</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
With the recent move to use .Net Standard 2.0, we broke the bundling of Sailthru.Models library into the Nuget package.

Correctly including dependencies seems to be a repeat pain point for Nuget as per https://github.com/dotnet/sdk/issues/6688, but the approach added here seem to work and can see the Model now being included in the compiled package
```
% unzip -l Sailthru.Client.1.2.1.nupkg
Archive:  Sailthru.Client.1.2.1.nupkg
  Length      Date    Time    Name
---------  ---------- -----   ----
      505  12-20-2022 13:59   _rels/.rels
      812  12-20-2022 13:59   Sailthru.Client.nuspec
    30208  12-20-2022 00:21   lib/netstandard2.0/Sailthru.Models.dll <-- was previously missing
    23040  12-20-2022 00:59   lib/netstandard2.0/Sailthru.dll
      459  12-20-2022 13:59   [Content_Types].xml
      644  12-20-2022 13:59   package/services/metadata/core-properties/fae2406158514c48b501b0980e09e4f2.psmdcp
---------                     -------
    55668                     6 files
```
Additionally Sailthru.Models is no longer a dependency inside `Sailthru.Client.nuspec` file so once uploaded Nuget should stop trying to reference it as a dependency to download.

Also fixed the license warning for good measure.