### PR TITLE
Update SailthruClient.cs to properly case StatusType used by GetBlastByStatus method to ensure successful response

### DIFF
--- a/Sailthru/Sailthru/SailthruClient.cs
+++ b/Sailthru/Sailthru/SailthruClient.cs
@@ -142,7 +142,8 @@ namespace Sailthru
         {
             Hashtable parameters = new Hashtable
             {
-                ["status"] = statusType
+                // Ensure the status type is in lowercase as required by the API
+                ["status"] = statusType.ToString().ToLower()
             };
             return ApiGet("blast", parameters);
         }


### PR DESCRIPTION
Addresses issue sailthru#79, make status type passed into API call lowercase so it returns a successful response from the Sailthru API.