### PR TITLE
Int-1638 Add link_params, fallback_time, and capping_enabled in BlastRequest

### DIFF
--- a/Sailthru/Sailthru.Models/BlastRequest.cs
+++ b/Sailthru/Sailthru.Models/BlastRequest.cs
@@ -82,7 +82,7 @@ namespace Sailthru.Models
         /// <summary>
         /// Gets or sets whether message frequency capping is enabled for this blast.
         /// Set to false to exclude this blast from the account's message frequency capping rules.
-        ///  If null, capping is enabled by default.
+        /// If null, capping is enabled by default.
         /// </summary>
         /// <value>True if frequency capping is enabled; false to exclude this blast from capping.</value>
         [JsonProperty(PropertyName = "capping_enabled")]

--- a/Sailthru/Sailthru.Models/BlastRequest.cs
+++ b/Sailthru/Sailthru.Models/BlastRequest.cs
@@ -80,11 +80,28 @@ namespace Sailthru.Models
         public long EmailCount { get; set; }
 
         /// <summary>
+        /// Gets or sets whether this blast is excluded from message frequency capping.
+        /// Set to false to exclude this blast from the account's message frequency capping rules.
+        /// </summary>
+        /// <value>Whether capping is enabled for this blast.</value>
+        [JsonProperty(PropertyName = "capping_enabled")]
+        public bool? CappingEnabled { get; set; }
+
+        /// <summary>
         /// Gets or sets the email hour range.
         /// </summary>
         /// <value>The email hour range.</value>
         [JsonProperty(PropertyName = "email_hour_range")]
         public int EmailHourRange { get; set; }
+
+        /// <summary>
+        /// Gets or sets the fallback time for personalized send time.
+        /// Used when subscriber engagement data is unavailable. Must fall within the
+        /// send window defined by email_hour_range starting at schedule_time.
+        /// </summary>
+        /// <value>The fallback send time, e.g. "12:00 PM EST" or "10:30 AM".</value>
+        [JsonProperty(PropertyName = "fallback_time")]
+        public string FallbackTime { get; set; }
 
         /// <summary>
         /// Gets or sets the end time.

--- a/Sailthru/Sailthru.Models/BlastRequest.cs
+++ b/Sailthru/Sailthru.Models/BlastRequest.cs
@@ -80,10 +80,11 @@ namespace Sailthru.Models
         public long EmailCount { get; set; }
 
         /// <summary>
-        /// Gets or sets whether this blast is excluded from message frequency capping.
+        /// Gets or sets whether message frequency capping is enabled for this blast.
         /// Set to false to exclude this blast from the account's message frequency capping rules.
+        ///  If null, capping is enabled by default.
         /// </summary>
-        /// <value>Whether capping is enabled for this blast.</value>
+        /// <value>True if frequency capping is enabled; false to exclude this blast from capping.</value>
         [JsonProperty(PropertyName = "capping_enabled")]
         public bool? CappingEnabled { get; set; }
 

--- a/Sailthru/Sailthru.Models/BlastRequest.cs
+++ b/Sailthru/Sailthru.Models/BlastRequest.cs
@@ -153,6 +153,13 @@ namespace Sailthru.Models
         public string LinkDomain { get; set; }
 
         /// <summary>
+        /// Gets or sets the link params.
+        /// </summary>
+        /// <value>The link params.</value>
+        [JsonProperty(PropertyName = "link_params")]
+        public Hashtable LinkParams { get; set; }
+
+        /// <summary>
         /// Gets or sets the link tracking.
         /// </summary>
         /// <value>The link tracking.</value>

--- a/Sailthru/Sailthru.Tests/Mock/BlastApi.cs
+++ b/Sailthru/Sailthru.Tests/Mock/BlastApi.cs
@@ -15,6 +15,7 @@ namespace Sailthru.Tests.Mock
             string modifyTime = DateTime.Now.ToLocalTime().ToString("ddd, dd MMM yyyy HH:mm:ss zzz");
             string linkDomain = (string)request["link_domain"];
             string status = (string)request["status"];
+            JObject linkParams = request.ContainsKey("link_params") ? request["link_params"] as JObject : null;
             JArray seedEmails = request.ContainsKey("seed_emails") ? request["seed_emails"] as JArray : null;
             JObject labels = request.ContainsKey("labels") ? request["labels"] as JObject : null;
 
@@ -64,6 +65,7 @@ namespace Sailthru.Tests.Mock
                 ["list"] = list,
                 ["modify_time"] = modifyTime,
                 ["link_domain"] = linkDomain,
+                ["link_params"] = linkParams,
                 ["seed_emails"] = seedEmails,
                 ["labels"] = blastLabels,
                 ["status"] = status,

--- a/Sailthru/Sailthru.Tests/Mock/BlastApi.cs
+++ b/Sailthru/Sailthru.Tests/Mock/BlastApi.cs
@@ -18,6 +18,8 @@ namespace Sailthru.Tests.Mock
             JObject linkParams = request.ContainsKey("link_params") ? request["link_params"] as JObject : null;
             JArray seedEmails = request.ContainsKey("seed_emails") ? request["seed_emails"] as JArray : null;
             JObject labels = request.ContainsKey("labels") ? request["labels"] as JObject : null;
+            string fallbackTime = (string)request["fallback_time"];
+            bool? cappingEnabled = request.ContainsKey("capping_enabled") ? request["capping_enabled"].Value<bool>() : (bool?)null;
 
             List<string> blastLabels = new();
             if (labels != null)
@@ -69,6 +71,8 @@ namespace Sailthru.Tests.Mock
                 ["seed_emails"] = seedEmails,
                 ["labels"] = blastLabels,
                 ["status"] = status,
+                ["fallback_time"] = fallbackTime,
+                ["capping_enabled"] = cappingEnabled,
             };
 
             if (request.ContainsKey("previous_blast_id"))

--- a/Sailthru/Sailthru.Tests/Tests.cs
+++ b/Sailthru/Sailthru.Tests/Tests.cs
@@ -297,6 +297,30 @@ namespace Sailthru.Tests
         }
 
         [TestMethod]
+        public void PostBlastWithLinkParams()
+        {
+            BlastRequest request = new()
+            {
+                Name = "Link Params Test",
+                List = "list",
+                Subject = "Test Subject",
+                ScheduleTime = "+3 hours",
+                LinkParams = new Hashtable
+                {
+                    { "utm_source", "sailthru" },
+                    { "utm_campaign", "summer_sale" }
+                }
+            };
+
+            SailthruResponse response = _client.ScheduleBlast(request);
+            Assert.IsTrue(response.IsOK());
+
+            Hashtable linkParams = response.HashtableResponse["link_params"] as Hashtable;
+            Assert.AreEqual("sailthru", linkParams["utm_source"]);
+            Assert.AreEqual("summer_sale", linkParams["utm_campaign"]);
+        }
+
+        [TestMethod]
         public void PostScheduledBlastNoScheduleTime()
         {
             BlastRequest request = new()

--- a/Sailthru/Sailthru.Tests/Tests.cs
+++ b/Sailthru/Sailthru.Tests/Tests.cs
@@ -308,7 +308,7 @@ namespace Sailthru.Tests
                 LinkParams = new Hashtable
                 {
                     { "utm_source", "sailthru" },
-                    { "utm_campaign", "summer_sale" }
+                    { "utm_campaign", "test_run" }
                 }
             };
 
@@ -317,7 +317,42 @@ namespace Sailthru.Tests
 
             Hashtable linkParams = response.HashtableResponse["link_params"] as Hashtable;
             Assert.AreEqual("sailthru", linkParams["utm_source"]);
-            Assert.AreEqual("summer_sale", linkParams["utm_campaign"]);
+            Assert.AreEqual("test_run", linkParams["utm_campaign"]);
+        }
+
+        [TestMethod]
+        public void PostBlastWithFallbackTime()
+        {
+            BlastRequest request = new()
+            {
+                Name = "Fallback Time Test",
+                List = "list",
+                Subject = "Test Subject",
+                ScheduleTime = "+3 hours",
+                EmailHourRange = 8,
+                FallbackTime = "12:00 PM EST"
+            };
+
+            SailthruResponse response = _client.ScheduleBlast(request);
+            Assert.IsTrue(response.IsOK());
+            Assert.AreEqual("12:00 PM EST", response.HashtableResponse["fallback_time"]);
+        }
+
+        [TestMethod]
+        public void PostBlastWithCappingDisabled()
+        {
+            BlastRequest request = new()
+            {
+                Name = "Capping Disabled Test",
+                List = "list",
+                Subject = "Test Subject",
+                ScheduleTime = "+3 hours",
+                CappingEnabled = false
+            };
+
+            SailthruResponse response = _client.ScheduleBlast(request);
+            Assert.IsTrue(response.IsOK());
+            Assert.AreEqual(false, response.HashtableResponse["capping_enabled"]);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
Added three new parameters to BlastRequest:

- `link_params` – Appends custom query parameters to every tracked link in the blast
- `fallback_time` – Sets a fallback send time when subscriber engagement data is unavailable (requires `email_hour_range`)
- `capping_enabled` – Set to `false` to exclude the blast from message frequency capping
