### PR TITLE
fix: upgrade actions/checkout v3 → v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     name: .Net version ${{ matrix.dotnet }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: ./Sailthru
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v3` → `@v4` in `build.yml` and `release.yml`
- Node.js 20 actions are deprecated; runners will force Node.js 24 by default from June 16th 2026 and remove Node.js 20 entirely on September 16th 2026

## Test plan
- [ ] Verify the build workflow passes on this PR

Closes [INF-9661](https://sailthru.atlassian.net/browse/INF-9661)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INF-9661]: https://sailthru.atlassian.net/browse/INF-9661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ