### PR TITLE
fix: install .NET 6 runtime in CI matrix to run net6.0 tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,12 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: |
-          6.0.x
-          ${{ matrix.dotnet }}
+        dotnet-version: ${{ matrix.dotnet }}
+    - name: Setup .NET 6 runtime (for running net6.0 tests)
+      if: matrix.dotnet != '6.0.x'
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: ${{ matrix.dotnet }}
+        dotnet-version: |
+          6.0.x
+          ${{ matrix.dotnet }}
     - name: Restore dependencies
       run: dotnet restore
     - name: Build


### PR DESCRIPTION
## Summary
- The `.Net version 7.0.x` CI job has been failing on every recorded run: it only installs the .NET 7 SDK, but `Sailthru.Tests.csproj` targets `net6.0`, so there's no matching runtime available to execute the compiled test binary.
- Updates the `Setup .NET` step in `build.yml` to always install `6.0.x` alongside whichever SDK the matrix is testing, so the net6.0 test runtime is present regardless of matrix leg.

## Root cause
```
Testhost process for source(s) '.../Sailthru.Tests/bin/Release/net6.0/Sailthru.Tests.dll' exited with error:
You must install or update .NET to run this application.
```
The 7.0.x job only had .NET 7 (plus preinstalled 8/9/10) runtimes available, not 6.0, so it could build the net6.0 test assembly but not run it.

## Test plan
- [ ] Verify both `.Net version 6.0.x` and `.Net version 7.0.x` jobs pass on this PR